### PR TITLE
Fix toolbar themes/icon colors, improve navdrawer UI

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -26,6 +26,7 @@
         android:theme="@style/Theme.GitHub">
         <activity
             android:name=".ui.MainActivity"
+            android:theme="@style/Theme.GitHub.NavigationDrawer"
             android:configChanges="orientation|keyboardHidden|screenSize"
             android:hardwareAccelerated="true">
             <intent-filter>

--- a/app/res/layout/activity_main.xml
+++ b/app/res/layout/activity_main.xml
@@ -14,6 +14,7 @@
         <android.support.v7.widget.Toolbar
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:paddingTop="@dimen/toolbar_top_padding"
             app:theme="@style/ToolbarStyle"
             android:minHeight="?attr/actionBarSize"
             android:background="?attr/colorPrimary"

--- a/app/res/layout/activity_main.xml
+++ b/app/res/layout/activity_main.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
@@ -13,6 +14,7 @@
         <android.support.v7.widget.Toolbar
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            app:theme="@style/ToolbarStyle"
             android:minHeight="?attr/actionBarSize"
             android:background="?attr/colorPrimary"
             android:id="@+id/toolbar" />

--- a/app/res/layout/commit_compare.xml
+++ b/app/res/layout/commit_compare.xml
@@ -14,12 +14,14 @@
   limitations under the License.
 -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <android.support.v7.widget.Toolbar
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:theme="@style/ToolbarStyle"
         android:minHeight="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
         android:id="@+id/toolbar" />

--- a/app/res/layout/commit_file_view.xml
+++ b/app/res/layout/commit_file_view.xml
@@ -15,12 +15,14 @@
 -->
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <android.support.v7.widget.Toolbar
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:theme="@style/ToolbarStyle"
         android:minHeight="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
         android:layout_alignParentTop="true"

--- a/app/res/layout/fragment_navigation_drawer.xml
+++ b/app/res/layout/fragment_navigation_drawer.xml
@@ -5,9 +5,9 @@
     android:layout_height="match_parent"
     tools:context=".NavigationDrawerFragment">
 
-    <RelativeLayout
+    <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="@dimen/abc_action_bar_default_height_material"
+        android:layout_height="@dimen/nav_drawer_header_height"
         android:id="@+id/navigation_drawer_header">
 
         <ImageView
@@ -16,26 +16,43 @@
             android:scaleType="centerCrop"
             android:src="@drawable/navigation_drawer_header_background" />
 
-        <ImageView
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:id="@+id/user_picture"
-            android:layout_centerVertical="true"
-            android:layout_margin="16dp" />
-
-        <TextView
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:id="@+id/user_name"
-            android:textAppearance="@style/TextAppearance.AppCompat.Body2"
-            android:textColor="#DEDEDE"
-            android:layout_marginEnd="16dp"
-            android:layout_marginRight="16dp"
-            android:layout_centerVertical="true"
-            android:layout_toRightOf="@+id/user_picture"
-            android:layout_toEndOf="@id/user_picture" />
+            android:paddingTop="@dimen/toolbar_top_padding"
+            android:layout_margin="16dp"
+            android:orientation="vertical"
+            android:layout_gravity="bottom"
+            >
 
-    </RelativeLayout>
+            <ImageView
+                android:layout_width="56dp"
+                android:layout_height="56dp"
+                android:id="@+id/user_picture"
+                android:contentDescription="user_avatar"
+                />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:id="@+id/user_real_name"
+                android:textAppearance="@style/TextAppearance.AppCompat.Subhead"
+                android:textColor="#DEDEDE"
+                android:layout_marginTop="16dp"
+                />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:id="@+id/user_name"
+                android:textAppearance="@style/TextAppearance.AppCompat.Subhead"
+                android:textColor="#DEDEDE"
+                android:layout_marginTop="16dp"
+                />
+
+        </LinearLayout>
+
+    </FrameLayout>
 
     <ListView
         android:paddingTop="8dp"

--- a/app/res/layout/gist_create.xml
+++ b/app/res/layout/gist_create.xml
@@ -14,12 +14,14 @@
   limitations under the License.
 -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <android.support.v7.widget.Toolbar
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:theme="@style/ToolbarStyle"
         android:layout_alignParentTop="true"
         android:minHeight="?attr/actionBarSize"
         android:background="?attr/colorPrimary"

--- a/app/res/layout/issue_edit.xml
+++ b/app/res/layout/issue_edit.xml
@@ -14,12 +14,14 @@
   limitations under the License.
 -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <android.support.v7.widget.Toolbar
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:theme="@style/ToolbarStyle"
         android:minHeight="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
         android:id="@+id/toolbar" />

--- a/app/res/layout/issue_search.xml
+++ b/app/res/layout/issue_search.xml
@@ -14,12 +14,14 @@
   limitations under the License.
 -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <android.support.v7.widget.Toolbar
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:theme="@style/ToolbarStyle"
         android:minHeight="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
         android:layout_alignParentTop="true"

--- a/app/res/layout/issues_filter_edit.xml
+++ b/app/res/layout/issues_filter_edit.xml
@@ -14,12 +14,14 @@
   limitations under the License.
 -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <android.support.v7.widget.Toolbar
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:theme="@style/ToolbarStyle"
         android:minHeight="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
         android:layout_alignParentTop="true"

--- a/app/res/layout/issues_filter_list.xml
+++ b/app/res/layout/issues_filter_list.xml
@@ -14,12 +14,14 @@
   limitations under the License.
 -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <android.support.v7.widget.Toolbar
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:theme="@style/ToolbarStyle"
         android:minHeight="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
         android:layout_alignParentTop="true"

--- a/app/res/layout/login.xml
+++ b/app/res/layout/login.xml
@@ -14,6 +14,7 @@
   limitations under the License.
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -21,6 +22,7 @@
     <android.support.v7.widget.Toolbar
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:theme="@style/ToolbarStyle"
         android:minHeight="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
         android:id="@+id/toolbar" />

--- a/app/res/layout/login_two_factor_auth.xml
+++ b/app/res/layout/login_two_factor_auth.xml
@@ -14,6 +14,7 @@
   limitations under the License.
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -21,6 +22,7 @@
     <android.support.v7.widget.Toolbar
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:theme="@style/ToolbarStyle"
         android:minHeight="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
         android:id="@+id/toolbar" />

--- a/app/res/layout/pager.xml
+++ b/app/res/layout/pager.xml
@@ -14,6 +14,7 @@
   limitations under the License.
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_height="match_parent"
     android:layout_width="match_parent"
     android:orientation="vertical">
@@ -21,6 +22,7 @@
     <android.support.v7.widget.Toolbar
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:theme="@style/ToolbarStyle"
         android:minHeight="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
         android:id="@+id/toolbar" />

--- a/app/res/layout/pager_with_tabs.xml
+++ b/app/res/layout/pager_with_tabs.xml
@@ -14,6 +14,7 @@
   limitations under the License.
 -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -21,6 +22,7 @@
     <android.support.v7.widget.Toolbar
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:theme="@style/ToolbarStyle"
         android:layout_alignParentTop="true"
         android:minHeight="?attr/actionBarSize"
         android:background="?attr/colorPrimary"

--- a/app/res/layout/pager_with_title.xml
+++ b/app/res/layout/pager_with_title.xml
@@ -23,6 +23,7 @@
     <android.support.v7.widget.Toolbar
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:theme="@style/ToolbarStyle"
         android:minHeight="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
         android:id="@+id/toolbar" />

--- a/app/res/layout/repo_contributors.xml
+++ b/app/res/layout/repo_contributors.xml
@@ -14,12 +14,14 @@
   limitations under the License.
 -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <android.support.v7.widget.Toolbar
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:theme="@style/ToolbarStyle"
         android:minHeight="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
         android:layout_alignParentTop="true"

--- a/app/res/layout/repo_issue_list.xml
+++ b/app/res/layout/repo_issue_list.xml
@@ -14,12 +14,14 @@
   limitations under the License.
 -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <android.support.v7.widget.Toolbar
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:theme="@style/ToolbarStyle"
         android:minHeight="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
         android:layout_alignParentTop="true"

--- a/app/res/values-v21/dimens.xml
+++ b/app/res/values-v21/dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="toolbar_top_padding">24dp</dimen>
+    <dimen name="nav_drawer_header_height">178dp</dimen>
+</resources>

--- a/app/res/values-v21/themes.xml
+++ b/app/res/values-v21/themes.xml
@@ -16,6 +16,7 @@
 
     <style name="Theme.GitHub.NavigationDrawer" parent="Theme.GitHub">
         <item name="android:windowTranslucentStatus">true</item>
+        <item name="colorControlHighlight">@color/ripple_material_light</item>
     </style>
 
 </resources>

--- a/app/res/values-v21/themes.xml
+++ b/app/res/values-v21/themes.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.GitHub" parent="@style/Theme.AppCompat.NoActionBar">
+
+        <item name="colorPrimary">@color/primary</item>
+        <item name="colorPrimaryDark">@color/primary_dark</item>
+        <item name="colorAccent">@color/accent</item>
+
+        <item name="actionBarPopupTheme">@style/ThemeOverlay.AppCompat.Dark</item>
+
+        <item name="actionBarStyle">@style/Widget.Styled.ActionBar</item>
+        <item name="android:actionBarStyle">@style/Widget.Styled.ActionBar</item>
+        <item name="windowActionBar">false</item>
+        <item name="android:windowBackground">@color/background</item>
+    </style>
+
+    <style name="Theme.GitHub.NavigationDrawer" parent="Theme.GitHub">
+        <item name="android:windowTranslucentStatus">true</item>
+    </style>
+
+</resources>

--- a/app/res/values/dimens.xml
+++ b/app/res/values/dimens.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="navigation_drawer_width">304dp</dimen>
+    <dimen name="toolbar_top_padding">0dp</dimen>
+    <dimen name="nav_drawer_header_height">152dp</dimen>
 </resources>

--- a/app/res/values/theme.xml
+++ b/app/res/values/theme.xml
@@ -29,7 +29,9 @@
         <item name="android:windowBackground">@color/background</item>
     </style>
 
-    <style name="Theme.GitHub.NavigationDrawer" parent="Theme.GitHub" />
+    <style name="Theme.GitHub.NavigationDrawer" parent="Theme.GitHub" >
+        <item name="colorControlHighlight">@color/ripple_material_light</item>
+    </style>
 
     <style name="Widget.Styled.ActionBar" parent="Widget.AppCompat.ActionBar.Solid">
         <item name="background">@drawable/actionbar_background</item>

--- a/app/res/values/theme.xml
+++ b/app/res/values/theme.xml
@@ -21,8 +21,6 @@
         <item name="colorPrimaryDark">@color/primary_dark</item>
         <item name="colorAccent">@color/accent</item>
 
-        <item name="colorControlHighlight">@color/ripple_material_light</item>
-
         <item name="actionBarPopupTheme">@style/ThemeOverlay.AppCompat.Dark</item>
 
         <item name="actionBarStyle">@style/Widget.Styled.ActionBar</item>
@@ -41,6 +39,11 @@
     <style name="IndeterminateProgress" parent="@android:style/Widget.ProgressBar">
         <item name="android:indeterminateDrawable">@drawable/actionbar_spinner</item>
         <item name="android:minWidth">16dp</item>
+    </style>
+
+    <style name="ToolbarStyle">
+        <item name="colorControlNormal">@android:color/white</item>
+        <item name="colorControlHighlight">@color/ripple_material_dark</item>
     </style>
 
 </resources>

--- a/app/res/values/theme.xml
+++ b/app/res/values/theme.xml
@@ -29,6 +29,8 @@
         <item name="android:windowBackground">@color/background</item>
     </style>
 
+    <style name="Theme.GitHub.NavigationDrawer" parent="Theme.GitHub" />
+
     <style name="Widget.Styled.ActionBar" parent="Widget.AppCompat.ActionBar.Solid">
         <item name="background">@drawable/actionbar_background</item>
         <item name="android:background">@drawable/actionbar_background</item>

--- a/app/src/main/java/com/github/mobile/ui/NavigationDrawerAdapter.java
+++ b/app/src/main/java/com/github/mobile/ui/NavigationDrawerAdapter.java
@@ -86,24 +86,24 @@ public class NavigationDrawerAdapter extends BaseAdapter {
             viewHolder = new ViewHolder();
             switch (obj.getType()) {
                 case TYPE_ITEM_MENU:
-                    convertView = inflater.inflate(R.layout.navigation_drawer_list_item_text, null);
+                    convertView = inflater.inflate(R.layout.navigation_drawer_list_item_text, parent, false);
                     viewHolder.name = (TextView) convertView.findViewById(R.id.navigation_drawer_item_name);
                     viewHolder.iconString = (TextView) convertView.findViewById(R.id.navigation_drawer_item_text_icon);
                     break;
                 case TYPE_ITEM_ORG:
-                    convertView = inflater.inflate(R.layout.navigation_drawer_list_item_image, null);
+                    convertView = inflater.inflate(R.layout.navigation_drawer_list_item_image, parent, false);
                     viewHolder.name = (TextView) convertView.findViewById(R.id.navigation_drawer_item_name);
                     viewHolder.iconDrawable = (ImageView) convertView.findViewById(R.id
                         .navigation_drawer_item_drawable_icon);
                     break;
                 case TYPE_SUBHEADER:
-                    convertView = inflater.inflate(R.layout.navigation_drawer_list_subheader, null);
+                    convertView = inflater.inflate(R.layout.navigation_drawer_list_subheader, parent, false);
                     viewHolder.name = (TextView) convertView.findViewById(R.id.navigation_drawer_item_name);
                     convertView.setEnabled(false);
                     convertView.setOnClickListener(null);
                     break;
                 default:
-                    convertView = inflater.inflate(R.layout.navigation_drawer_list_seperator, null);
+                    convertView = inflater.inflate(R.layout.navigation_drawer_list_seperator, parent, false);
                     convertView.setEnabled(false);
                     convertView.setOnClickListener(null);
                     break;

--- a/app/src/main/java/com/github/mobile/ui/NavigationDrawerFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/NavigationDrawerFragment.java
@@ -44,6 +44,7 @@ public class NavigationDrawerFragment extends Fragment implements AdapterView.On
     private boolean mUserLearnedDrawer;
 
     private ImageView userImage;
+    private TextView userRealName;
     private TextView userName;
 
     public NavigationDrawerFragment() {
@@ -87,6 +88,7 @@ public class NavigationDrawerFragment extends Fragment implements AdapterView.On
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         userImage = (ImageView) view.findViewById(R.id.user_picture);
+        userRealName = (TextView) view.findViewById(R.id.user_real_name);
         userName = (TextView) view.findViewById(R.id.user_name);
         mDrawerListView = (ListView) view.findViewById(R.id.navigation_drawer_list);
         mDrawerListView.setOnItemClickListener(this);
@@ -104,6 +106,13 @@ public class NavigationDrawerFragment extends Fragment implements AdapterView.On
 
         avatar.bind(userImage, user);
         userName.setText(user.getLogin());
+
+        String name = user.getName();
+        if (name != null) {
+            userRealName.setText(user.getName());
+        } else {
+            userRealName.setVisibility(View.GONE);
+        }
 
         mDrawerListView.setAdapter(adapter);
         mDrawerListView.setItemChecked(mCurrentSelectedPosition, true);


### PR DESCRIPTION
Been holding onto these changes for awhile, just kept forgetting to PR back.

This fixes the toolbar themes so that they have proper ripple and icon colors, while extracting them to an easy to reuse style. Before, the switch to nav drawer broke these themes and resulted in some weird behavior (black ripple on dark gray background, etc).

This also improves the navdrawer UI to be more in-line with material design's guidelines.
* Runs the nav drawer underneath the statusbar in lollipop+ devices to match the material spec
* Enlarges the text and avatar in the header
* Add real name text field and show if it's available
* Extend height of header to more naturally wrap the content within it
  * Later, if more granular profile controls are added, these would be controlled from here.

Screenshots:

![screenshot 2015-02-16 00 17 03](https://cloud.githubusercontent.com/assets/1361086/6208676/26fb4586-b571-11e4-9e1f-f3792daf7856.png)
